### PR TITLE
Inject flash messages into LoginAction

### DIFF
--- a/web/src/App/Action/LoginAction.php
+++ b/web/src/App/Action/LoginAction.php
@@ -10,14 +10,16 @@ class LoginAction
     protected $session;
     protected $guzzle;
     protected $settings;
+    protected $flash;
 
-    public function __construct(Logger $logger, $renderer, $session, $guzzle, $settings)
+    public function __construct(Logger $logger, $renderer, $session, $guzzle, $settings, $flash)
     {
         $this->logger = $logger;
         $this->renderer = $renderer;
         $this->session = $session;
         $this->guzzle = $guzzle;
         $this->settings = $settings;
+        $this->flash = $flash;
     }
 
     public function __invoke($request, $response)

--- a/web/src/App/Action/LoginAction.php
+++ b/web/src/App/Action/LoginAction.php
@@ -2,7 +2,7 @@
 namespace App\Action;
 
 use Monolog\Logger;
-
+use GuzzleHttp\Exception\TransferException;
 class LoginAction
 {
     protected $logger;
@@ -34,11 +34,10 @@ class LoginAction
             ];
 
             $res = $this->guzzle->post('/token', ['json' => $data]);
-        } catch (\GuzzleHttp\Exception\TransferException $e) {
+        } catch (TransferException $e) {
             $this->flash->addMessage('error', "Failed to log in: " . $e->getMessage());
             return $response->withRedirect('/login');
         }
-
 
         $data = json_decode($res->getBody(), true);
         $this->session->username = $request->getParam('username');

--- a/web/src/dependencies.php
+++ b/web/src/dependencies.php
@@ -70,7 +70,8 @@ $container[App\Action\LoginAction::class] = function ($c) {
     $session = $c->get('session');
     $guzzle = $c->get('guzzle');
     $settings = $c->get('settings');
-    return new App\Action\LoginAction($logger, $renderer, $session, $guzzle, $settings);
+    $flash = $c->get('flash');
+    return new App\Action\LoginAction($logger, $renderer, $session, $guzzle, $settings, $flash);
 };
 
 $container[App\Action\AuthoriseFormAction::class] = function ($c) {


### PR DESCRIPTION
The Flash Messages instance is required in LoginAction for when the user fails to log in.

Fixes #2 