### PR TITLE
Enable demo to work (populating default schema) and fix unreferenced "expires" key

### DIFF
--- a/api/db/fixtures/default.sql
+++ b/api/db/fixtures/default.sql
@@ -129,13 +129,13 @@ INSERT INTO book (book_id, author_id, title, isbn, created, updated) VALUES ('8b
 INSERT INTO oauth_clients
 (client_id, client_secret, redirect_uri)
 VALUES
-("mywebsite", "$2y$10$Qq1CsKsY1eHLewwC.EZYM.x71bxJOXibz1dXetEEBrawQu90VVLV6", null);
+("mywebsite", "$2y$10$Qq1CsKsY1eHLewwC.EZYM.x71bxJOXibz1dXetEEBrawQu90VVLV6", 'http://localhost:8889/');
 
 -- A 3rd party client: testclient/abcdef
 INSERT INTO oauth_clients
 (client_id, client_secret, redirect_uri)
 VALUES
-("testclient", "$2y$10$Qq1CsKsY1eHLewwC.EZYM.x71bxJOXibz1dXetEEBrawQu90VVLV6", null);
+("testclient", "$2y$10$Qq1CsKsY1eHLewwC.EZYM.x71bxJOXibz1dXetEEBrawQu90VVLV6", '');
 
 -- A test user: rob/123456
 INSERT INTO oauth_users

--- a/web/src/App/Action/LoginAction.php
+++ b/web/src/App/Action/LoginAction.php
@@ -42,7 +42,7 @@ class LoginAction
         $data = json_decode($res->getBody(), true);
         $this->session->username = $request->getParam('username');
         $this->session->access_token = $data['access_token'];
-        $this->session->expires = strtotime('+' . $data['expires'] . ' seconds');
+        $this->session->expires = strtotime('+' . $data['expires_in'] . ' seconds');
         $this->session->refresh_token = $data['refresh_token'];
 
         if ($r = $request->getQueryParam('r')) {


### PR DESCRIPTION
When running the set-up, loading the fixtures (`cat api/db/fixtures/default.sql | sqlite3 api/db/bookshelf.db`) fails due to non-null `redirect_uri` field.

Seems [it should be non-null, as well](https://github.com/bshaffer/oauth2-server-php/blob/master/src/OAuth2/Storage/ClientInterface.php), so have populated what might be "sensible" values (and the app loads and works).

Additionally, the field returned by Oauth response is "expires_in", not "expires", so fixed unreferenced error: `PHP Notice:  Undefined index: expires in slim-bookshelf-api/web/src/App/Action/LoginAction.php on line 46`